### PR TITLE
Fix/suite unit e pint

### DIFF
--- a/deep-dish-backend/app/Http/Controllers/DashboardController.php
+++ b/deep-dish-backend/app/Http/Controllers/DashboardController.php
@@ -16,12 +16,12 @@ class DashboardController extends Controller
         $restauranteId = auth('restaurante')->id();
 
         $queueSize = ClienteFila::query()
-        ->ativas()
-        ->whereHas('fila', fn ($q) => $q
-            ->where('restaurante_id', $restauranteId)
-            ->where('status', Fila::STATUS_ABERTA)
-        )
-        ->count();
+            ->ativas()
+            ->whereHas('fila', fn ($q) => $q
+                ->where('restaurante_id', $restauranteId)
+                ->where('status', Fila::STATUS_ABERTA)
+            )
+            ->count();
 
         $reservationsToday = ClienteMesa::whereHas('mesa', fn ($q) => $q
             ->where('restaurante_id', $restauranteId)

--- a/deep-dish-backend/app/Http/Controllers/HorariosController.php
+++ b/deep-dish-backend/app/Http/Controllers/HorariosController.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace App\Http\Controllers;
+
 use App\Models\Fila;
 use App\Models\Restaurante;
 use Illuminate\Http\JsonResponse;
@@ -42,7 +43,7 @@ class HorariosController extends Controller
             if ($tipo === null || $tipo === 'reservas') {
                 $relations['mesas.clienteMesas'] = fn ($q) => $q;
             }
-           if ($tipo === null || $tipo === 'fila') {
+            if ($tipo === null || $tipo === 'fila') {
                 $relations['filas'] = fn ($q) => $q->where('status', Fila::STATUS_ABERTA);
                 $relations['filas.clienteFilas'] = fn ($q) => $q
                     ->ativas()

--- a/deep-dish-backend/app/Models/ClienteFila.php
+++ b/deep-dish-backend/app/Models/ClienteFila.php
@@ -14,7 +14,9 @@ class ClienteFila extends Model
     use SoftDeletes;
 
     public const STATUS_SAIDA_DESISTIU = 'desistiu';
+
     public const STATUS_SAIDA_ATENDIDO = 'atendido';
+
     public const STATUS_SAIDA_REMOVIDO = 'removido'; // ação administrativa (item 6)
 
     public $incrementing = false;
@@ -35,9 +37,9 @@ class ClienteFila extends Model
     protected function casts(): array
     {
         return [
-            'created_at'            => 'datetime',
-            'updated_at'            => 'datetime',
-            'saiu_em'               => 'datetime',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+            'saiu_em' => 'datetime',
             'tempo_espera_segundos' => 'integer',
         ];
     }
@@ -48,7 +50,7 @@ class ClienteFila extends Model
             if ($registro->status_saida === null && ! $registro->isForceDeleting()) {
                 throw new \LogicException(
                     'ClienteFila: use registrarSaida($status) em vez de delete(). '
-                    . 'Apagar sem status_saida cria registro fantasma na fila.'
+                    .'Apagar sem status_saida cria registro fantasma na fila.'
                 );
             }
         });
@@ -72,8 +74,8 @@ class ClienteFila extends Model
         $agora = now();
 
         $this->forceFill([
-            'status_saida'          => $status,
-            'saiu_em'               => $agora,
+            'status_saida' => $status,
+            'saiu_em' => $agora,
             'tempo_espera_segundos' => (int) abs($this->created_at->diffInSeconds($agora)),
         ])->save();
 
@@ -95,10 +97,10 @@ class ClienteFila extends Model
             ->where('fila_id', $this->fila_id)
             ->where(function (Builder $q) {
                 $q->where('created_at', '<', $this->created_at)
-                  ->orWhere(function (Builder $q2) {
-                      $q2->where('created_at', '=', $this->created_at)
-                         ->where('id', '<', $this->id);
-                  });
+                    ->orWhere(function (Builder $q2) {
+                        $q2->where('created_at', '=', $this->created_at)
+                            ->where('id', '<', $this->id);
+                    });
             })
             ->count();
     }

--- a/deep-dish-backend/database/migrations/2026_08_12_175616_add_saida_and_soft_deletes_to_cliente_fila_table.php
+++ b/deep-dish-backend/database/migrations/2026_08_12_175616_add_saida_and_soft_deletes_to_cliente_fila_table.php
@@ -9,26 +9,26 @@ return new class extends Migration
     /**
      * Run the migrations.
      */
-   public function up(): void
-{
-    Schema::table('clientefila', function (Blueprint $table) {
-        $table->string('status_saida')->nullable();
-        $table->timestamp('saiu_em')->nullable();
-        $table->unsignedInteger('tempo_espera_segundos')->nullable();
-        $table->softDeletes();
-    });
-}
+    public function up(): void
+    {
+        Schema::table('clientefila', function (Blueprint $table) {
+            $table->string('status_saida')->nullable();
+            $table->timestamp('saiu_em')->nullable();
+            $table->unsignedInteger('tempo_espera_segundos')->nullable();
+            $table->softDeletes();
+        });
+    }
 
-public function down(): void
-{
-    Schema::table('clientefila', function (Blueprint $table) {
-        $table->dropColumn([
-            'status_saida',
-            'saiu_em',
-            'tempo_espera_segundos',
-        ]);
+    public function down(): void
+    {
+        Schema::table('clientefila', function (Blueprint $table) {
+            $table->dropColumn([
+                'status_saida',
+                'saiu_em',
+                'tempo_espera_segundos',
+            ]);
 
-        $table->dropSoftDeletes();
-    });
-}
+            $table->dropSoftDeletes();
+        });
+    }
 };

--- a/deep-dish-backend/tests/Unit/ClienteFilaTest.php
+++ b/deep-dish-backend/tests/Unit/ClienteFilaTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\ClienteFila;
+use Tests\TestCase;
+
+/**
+ * Testes de unidade do ClienteFila — o model que guarda o histórico da fila.
+ *
+ * Nenhum destes testes toca o banco: todos exercitam caminhos que retornam
+ * antes de qualquer consulta. Isso é proposital, para a suíte Unit continuar
+ * rodando mesmo enquanto a infraestrutura de banco de teste não existe.
+ */
+class ClienteFilaTest extends TestCase
+{
+    public function test_constantes_de_status_saida_tem_os_valores_gravados_no_banco(): void
+    {
+        // Os valores viram string na coluna status_saida e são lidos pelo
+        // Analytics do Sprint 2. Renomear em silêncio invalidaria o histórico.
+        $this->assertSame('desistiu', ClienteFila::STATUS_SAIDA_DESISTIU);
+        $this->assertSame('atendido', ClienteFila::STATUS_SAIDA_ATENDIDO);
+        $this->assertSame('removido', ClienteFila::STATUS_SAIDA_REMOVIDO);
+    }
+
+    public function test_quem_ja_saiu_da_fila_nao_tem_posicao(): void
+    {
+        $registro = new ClienteFila;
+        $registro->status_saida = ClienteFila::STATUS_SAIDA_ATENDIDO;
+
+        $this->assertNull($registro->posicao);
+    }
+
+    public function test_registrar_saida_e_idempotente(): void
+    {
+        $registro = new ClienteFila;
+        $registro->status_saida = ClienteFila::STATUS_SAIDA_DESISTIU;
+        $registro->saiu_em = now()->subHour();
+
+        $saiuEmOriginal = $registro->saiu_em;
+
+        // Segunda chamada não pode sobrescrever o histórico já gravado.
+        $registro->registrarSaida(ClienteFila::STATUS_SAIDA_REMOVIDO);
+
+        $this->assertSame(ClienteFila::STATUS_SAIDA_DESISTIU, $registro->status_saida);
+        $this->assertTrue($saiuEmOriginal->equalTo($registro->saiu_em));
+    }
+
+    public function test_scope_ativas_filtra_por_status_saida_nulo(): void
+    {
+        $sql = strtolower(ClienteFila::query()->ativas()->toSql());
+
+        $this->assertStringContainsString('status_saida', $sql);
+        $this->assertStringContainsString('is null', $sql);
+    }
+
+    public function test_posicao_nao_esta_no_appends(): void
+    {
+        // Estava no $appends e disparava um COUNT por registro serializado.
+        // O Sprint 3 vai transmitir a fila por broadcast, o que amplificaria
+        // esse N+1 — por isso a ausência aqui é comportamento, não detalhe.
+        $this->assertNotContains('posicao', (new ClienteFila)->getAppends());
+    }
+}


### PR DESCRIPTION
Devolve a `develop` ao verde. Dois problemas, ambos surgidos depois do merge do #187.

**1. `composer test` estava quebrado** (`exit 2`) — regressão do próprio #187, que
apagou o único arquivo de `tests/Unit/`. Git não versiona pasta vazia, então o
diretório sumiu e o `phpunit.xml` ficou apontando para o nada. Corrigido com
5 testes reais do `ClienteFila` (o model reescrito no #188), sem dependência de banco.

**2. `pint --test` acusava 4 arquivos** vindos dos #188 e #189. Só formatação.

Os seis checks passam: `pint`, `phpunit` (8 testes), `eslint`, `tsc`, `vitest`, `build`.
