### PR TITLE
Chore/workflow ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,158 @@
+name: CI
+
+# Roda a cada PR para develop/main e nos merges nessas branches.
+#
+# Nao usamos filtro por `paths` de proposito: quando os checks virarem
+# obrigatorios (issue #185), um job que nao roda nunca reporta status e o PR
+# trava para sempre em "waiting for status". Rodar sempre custa ~4 min.
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+# Cancela runs antigos do mesmo PR quando chega commit novo.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ─────────────────────────────────────────────────────────────
+  # Backend — Laravel 12 / PHP 8.2 / PostgreSQL
+  # ─────────────────────────────────────────────────────────────
+  backend:
+    name: Backend (PHP 8.2)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: deep-dish-backend
+
+    services:
+      # Postgres efemero, criado e destruido a cada run.
+      # Nunca encosta no Supabase do time.
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: secret
+          POSTGRES_DB: deepdish_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      # Estas variaveis VENCEM o phpunit.xml, que fixa sqlite.
+      # O PHPUnit so define um <env> se a variavel ainda nao existir
+      # (PhpHandler.php: `if ($force || getenv($name) === false)`), e o
+      # phpunit.xml deste projeto nao usa force="true".
+      #
+      # Assim os testes rodam contra Postgres sem alterar o phpunit.xml,
+      # que e escopo da issue #160.
+      #
+      # ATENCAO: se alguem adicionar force="true" ao phpunit.xml, os testes
+      # voltam para sqlite silenciosamente e este job perde o sentido.
+      DB_CONNECTION: pgsql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_DATABASE: deepdish_test
+      DB_USERNAME: postgres
+      DB_PASSWORD: secret
+      # O .env.example usa sslmode=require (Supabase); o container nao tem TLS.
+      DB_SSLMODE: disable
+      # A aplicacao boota sem Reverb; nao subimos o servidor de broadcast aqui.
+      BROADCAST_CONNECTION: "null"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          # Mesmas extensoes do deep-dish-backend/Dockerfile.
+          extensions: pdo, pdo_pgsql, bcmath, zip, pcntl
+          coverage: none
+
+      - name: Localizar o cache do Composer
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Restaurar cache do Composer
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-${{ hashFiles('deep-dish-backend/composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Instalar dependencias
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Preparar o .env
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+          # JWT_SECRET nao vem preenchido no .env.example e sem ele o
+          # tymon/jwt-auth derruba o boot da aplicacao.
+          php artisan jwt:secret --force
+
+      - name: Rodar as migrations em banco virgem
+        run: php artisan migrate --force
+
+      - name: Formatacao (Pint)
+        run: ./vendor/bin/pint --test
+
+      - name: Testes (PHPUnit)
+        run: php artisan test
+
+  # ─────────────────────────────────────────────────────────────
+  # Frontend — React 18 / Vite / Node 20
+  # ─────────────────────────────────────────────────────────────
+  frontend:
+    name: Frontend (Node 20)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: deep-dish-frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar Node
+        uses: actions/setup-node@v4
+        with:
+          # Mesma versao do servico frontend no docker-compose.yml.
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: deep-dish-frontend/package-lock.json
+
+      - name: Instalar dependencias
+        # npm ci exige package-lock.json em sincronia com package.json.
+        run: npm ci
+
+      - name: Preparar o .env
+        # O build le import.meta.env.VITE_*; sem o arquivo os valores ficam
+        # undefined e o resultado deixa de ser deterministico.
+        run: cp .env.example .env
+
+      - name: Lint (ESLint)
+        run: npm run lint
+
+      - name: Checagem de tipos (TypeScript)
+        # O `vite build` usa esbuild, que APAGA os tipos sem verifica-los.
+        # Sem este passo, nada no projeto valida TypeScript.
+        run: npx tsc --noEmit
+
+      - name: Testes (Vitest)
+        run: npm test
+
+      - name: Build de producao
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,13 +104,44 @@ jobs:
           php artisan jwt:secret --force
 
       - name: Rodar as migrations em banco virgem
-        run: php artisan migrate --force
+        id: migrate
+        run: |
+          saida=$(php artisan migrate --force)
+          echo "$saida"
+          total=$(echo "$saida" | grep -c "DONE" || true)
+          echo "total=$total" >> "$GITHUB_OUTPUT"
 
       - name: Formatacao (Pint)
+        id: pint
         run: ./vendor/bin/pint --test
 
       - name: Testes (PHPUnit)
-        run: php artisan test
+        id: phpunit
+        run: |
+          saida=$(php artisan test)
+          echo "$saida"
+          # A saida vem com codigos de cor ANSI; sem remover, o resumo fica ilegivel.
+          resumo=$(echo "$saida" | sed 's/\x1b\[[0-9;]*m//g' \
+            | grep -oE "Tests:.*" | tail -1 | sed 's/Tests:[[:space:]]*//')
+          echo "resumo=${resumo:-sem resumo}" >> "$GITHUB_OUTPUT"
+
+      # Escreve um resumo em markdown no topo da pagina do run.
+      # `if: always()` faz o resumo aparecer tambem quando algum passo falha —
+      # que e justamente quando ele mais ajuda.
+      - name: Resumo
+        if: always()
+        run: |
+          {
+            echo "## Backend — PHP 8.2 · PostgreSQL 16"
+            echo ""
+            echo "| Verificação | Resultado |"
+            echo "|---|---|"
+            echo "| Migrations em banco virgem | ${{ steps.migrate.outcome == 'success' && '✅' || '❌' }} ${{ steps.migrate.outputs.total }} passos |"
+            echo "| Formatação (Pint) | ${{ steps.pint.outcome == 'success' && '✅' || '❌' }} |"
+            echo "| Testes (PHPUnit) | ${{ steps.phpunit.outcome == 'success' && '✅' || '❌' }} ${{ steps.phpunit.outputs.resumo }} |"
+            echo ""
+            echo "Banco: container \`postgres:16\` efêmero — o Supabase do time não é tocado."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ─────────────────────────────────────────────────────────────
   # Frontend — React 18 / Vite / Node 20
@@ -144,15 +175,46 @@ jobs:
         run: cp .env.example .env
 
       - name: Lint (ESLint)
+        id: lint
         run: npm run lint
 
       - name: Checagem de tipos (TypeScript)
+        id: tipos
         # O `vite build` usa esbuild, que APAGA os tipos sem verifica-los.
         # Sem este passo, nada no projeto valida TypeScript.
         run: npx tsc --noEmit
 
       - name: Testes (Vitest)
-        run: npm test
+        id: vitest
+        run: |
+          saida=$(npm test)
+          echo "$saida"
+          # Remove os codigos de cor ANSI antes de extrair o resumo.
+          resumo=$(echo "$saida" | sed 's/\x1b\[[0-9;]*m//g' \
+            | grep -oE "Tests +[0-9]+ passed.*" | tail -1 | sed 's/Tests  *//')
+          echo "resumo=${resumo:-sem resumo}" >> "$GITHUB_OUTPUT"
 
       - name: Build de producao
-        run: npm run build
+        id: build
+        run: |
+          saida=$(npm run build)
+          echo "$saida"
+          tempo=$(echo "$saida" | sed 's/\x1b\[[0-9;]*m//g' \
+            | grep -oE "built in [0-9.]+s" | tail -1)
+          echo "tempo=${tempo:-concluido}" >> "$GITHUB_OUTPUT"
+
+      - name: Resumo
+        if: always()
+        run: |
+          {
+            echo "## Frontend — Node 20 · Vite"
+            echo ""
+            echo "| Verificação | Resultado |"
+            echo "|---|---|"
+            echo "| Lint (ESLint) | ${{ steps.lint.outcome == 'success' && '✅' || '❌' }} |"
+            echo "| Tipos (tsc --noEmit) | ${{ steps.tipos.outcome == 'success' && '✅' || '❌' }} |"
+            echo "| Testes (Vitest) | ${{ steps.vitest.outcome == 'success' && '✅' || '❌' }} ${{ steps.vitest.outputs.resumo }} |"
+            echo "| Build de produção | ${{ steps.build.outcome == 'success' && '✅' || '❌' }} ${{ steps.build.outputs.tempo }} |"
+            echo ""
+            echo "> O \`vite build\` não verifica tipos — quem faz isso é o passo \`tsc --noEmit\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@
 
 **Fila inteligente. Reservas sem fricção. Restaurantes no controle.**
 
+[![CI](https://github.com/joaogpereira/deep-dish/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/joaogpereira/deep-dish/actions/workflows/ci.yml)
+
 [![React](https://img.shields.io/badge/React-18-61DAFB?style=flat-square&logo=react&logoColor=black)](https://reactjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Vite](https://img.shields.io/badge/Vite-5-646CFF?style=flat-square&logo=vite&logoColor=white)](https://vitejs.dev/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind-3-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
-[![Laravel](https://img.shields.io/badge/Laravel-11-FF2D20?style=flat-square&logo=laravel&logoColor=white)](https://laravel.com/)
+[![Laravel](https://img.shields.io/badge/Laravel-12-FF2D20?style=flat-square&logo=laravel&logoColor=white)](https://laravel.com/)
 [![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?style=flat-square&logo=docker&logoColor=white)](https://www.docker.com/)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -192,6 +192,65 @@ VITE_API_URL=http://127.0.0.1:8000/api
 
 **Backend** — copie `deep-dish-backend/.env.example` e preencha banco de dados, JWT e SMTP.
 
+Gere as duas chaves obrigatórias (sem elas a aplicação não sobe):
+
+```bash
+php artisan key:generate   # APP_KEY
+php artisan jwt:secret     # JWT_SECRET
+```
+
+---
+
+## ✅ Integração Contínua
+
+Todo Pull Request para `develop` ou `main` dispara automaticamente o workflow
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml), com dois jobs em paralelo:
+
+| Job | O que verifica |
+|---|---|
+| **Backend** (PHP 8.2) | Formatação com Pint · migrations em banco virgem · testes PHPUnit |
+| **Frontend** (Node 20) | ESLint · checagem de tipos · Vitest · build de produção |
+
+O job de backend sobe um **PostgreSQL 16 efêmero** como *service container* — criado e destruído a
+cada execução, sem nunca encostar no banco compartilhado do time.
+
+### Reproduzindo localmente
+
+Rode antes de abrir o PR; os seis comandos precisam passar:
+
+```bash
+# backend
+cd deep-dish-backend
+./vendor/bin/pint --test      # formatação (sem --test, ele corrige)
+composer test                 # PHPUnit
+
+# frontend
+cd ../deep-dish-frontend
+npm run lint                  # ESLint
+npx tsc --noEmit              # tipos — o build NÃO checa isso
+npm test                      # Vitest
+npm run build                 # build de produção
+```
+
+> **Por que `npx tsc --noEmit` existe:** o `npm run build` usa esbuild, que *apaga* as anotações de
+> tipo sem verificá-las. Sem esse comando, nenhum erro de tipo é detectado antes de chegar no
+> navegador.
+
+Os testes rodam em SQLite na sua máquina e em PostgreSQL na CI. Se precisar reproduzir o ambiente
+da CI localmente, suba um Postgres descartável e aponte as variáveis para ele:
+
+```bash
+docker run -d --name dd-test -e POSTGRES_PASSWORD=secret \
+  -e POSTGRES_DB=deepdish_test -p 55432:5432 postgres:16
+
+cd deep-dish-backend
+DB_CONNECTION=pgsql DB_HOST=127.0.0.1 DB_PORT=55432 DB_DATABASE=deepdish_test \
+DB_USERNAME=postgres DB_PASSWORD=secret DB_SSLMODE=disable \
+  php artisan migrate --force && php artisan test
+
+docker rm -f dd-test
+```
+
 ---
 
 ## ⚙️ Worker de Filas

--- a/deep-dish-backend/.env.example
+++ b/deep-dish-backend/.env.example
@@ -4,6 +4,10 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+# Gere com: php artisan jwt:secret
+# Sem esta chave o tymon/jwt-auth derruba o boot da aplicacao.
+JWT_SECRET=
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
@@ -41,7 +45,7 @@ SESSION_ENCRYPT=false
 SESSION_PATH=/
 SESSION_DOMAIN=null
 
-BROADCAST_CONNECTION=log
+# BROADCAST_CONNECTION fica definido na secao de Reverb, no fim do arquivo.
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
 
@@ -81,6 +85,11 @@ FRONTEND_URL=http://localhost:8080
 
 # Broadcasting em tempo real (Laravel Reverb).
 # Gere as credenciais com: php artisan reverb:install
+#
+# Esta e a UNICA definicao de BROADCAST_CONNECTION no arquivo. Valores possiveis:
+#   reverb -> tempo real de verdade; exige o servico 'reverb' rodando
+#   log    -> escreve o evento no log em vez de transmitir (util sem o servico)
+#   null   -> descarta os eventos (usado pelos testes, via phpunit.xml)
 BROADCAST_CONNECTION=reverb
 REVERB_APP_ID=
 REVERB_APP_KEY=

--- a/deep-dish-backend/composer.json
+++ b/deep-dish-backend/composer.json
@@ -10,6 +10,7 @@
         "laravel/framework": "^12.0",
         "laravel/reverb": "^1.11",
         "laravel/tinker": "^2.10.1",
+        "pusher/pusher-php-server": "^7.3",
         "tymon/jwt-auth": "^2.2"
     },
     "require-dev": {

--- a/deep-dish-backend/composer.lock
+++ b/deep-dish-backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ae084efe31a52cc25e1f5befbef01c5",
+    "content-hash": "6502c7f0d5489e29a487b7b64bf9594e",
     "packages": [
         {
             "name": "brick/math",

--- a/docs/backlog-pi4.md
+++ b/docs/backlog-pi4.md
@@ -1090,22 +1090,42 @@ lint, teste e build só rodam se alguém lembrar de rodar na própria máquina.
 - Criar `.github/workflows/ci.yml` disparando em `pull_request` para `develop` e `main`, e em
   `push` nessas duas branches.
 - `concurrency` com `cancel-in-progress` para cancelar runs antigos do mesmo PR.
-- Filtro por `paths`: um PR que só toca `docs/` não deve rodar build de frontend nem migrations.
+- ~~Filtro por `paths`~~ — **revertido durante a execução.** Se um job não roda por causa de filtro,
+  ele nunca reporta status, e o check obrigatório da `#32` deixa o PR travado para sempre em
+  *waiting for status*. Os dois jobs rodam sempre; custa ~4 min por PR.
 - **Job `backend`:** `postgres:16` como service container; `setup-php` 8.2 com `pdo_pgsql`,
-  `bcmath` e `zip` (mesmas extensões do `Dockerfile`); cache do Composer; `composer install`;
-  gerar `.env` a partir do `.env.example` com `key:generate` e **`jwt:secret`** (o `.env.example`
-  não tem `JWT_SECRET`, e sem ele o boot quebra); `pint --test`; `php artisan test`.
+  `bcmath`, `zip` e `pcntl` (mesmas extensões do `Dockerfile`); cache do Composer;
+  `composer install`; gerar `.env` a partir do `.env.example` com `key:generate` e **`jwt:secret`**;
+  `php artisan migrate --force` (valida a cadeia de migrations em banco virgem); `pint --test`;
+  `php artisan test`.
 - **Job `frontend`:** `setup-node` 20 (mesma versão do `docker-compose`) com cache de npm;
-  `npm ci`; `npm run lint`; `npm test`; `npm run build`.
+  `npm ci`; `npm run lint`; **`npx tsc --noEmit`**; `npm test`; `npm run build`.
 - Os dois jobs rodam em paralelo e são independentes.
 - Documentar no `README` o que a CI verifica e como reproduzir localmente.
 
 **Critérios de aceite**
 - [ ] Abrir PR para `develop` dispara os dois jobs e ambos passam no código atual.
 - [ ] PR que quebra lint ou teste fica vermelho, com o erro legível no log.
-- [ ] PR que só altera `docs/` não roda os jobs de build.
 - [ ] Nenhum segredo aparece em log; nenhuma credencial real é necessária (o Postgres é efêmero).
 - [ ] Run completo em menos de ~5 min com cache quente.
+
+**Descobertas durante a execução**
+
+- **Os testes rodam contra Postgres sem alterar o `phpunit.xml`.** O PHPUnit só aplica um `<env>`
+  se a variável ainda não existir no ambiente (`PhpHandler.php:112`:
+  `if ($force || getenv($name) === false)`), e o `phpunit.xml` deste projeto não usa `force="true"`.
+  Logo, o `env:` do job vence o XML. Verificado: com as variáveis, `database.default` é `pgsql`;
+  sem elas, `sqlite`. Isso desacopla esta issue da `#7`. **Se a `#7` adicionar `force="true"`, a CI
+  volta silenciosamente para SQLite.**
+- **`npx tsc --noEmit` entrou no job de frontend.** O `vite build` usa esbuild, que apaga os tipos
+  sem verificá-los — hoje nada no projeto valida TypeScript. Ressalva: o `tsconfig.json` tem
+  `strictNullChecks` e `noImplicitAny` desligados, então a checagem é de malha larga (ver a seção
+  de ideias futuras).
+- **Bug encontrado e corrigido junto:** o `.env.example` define `BROADCAST_CONNECTION=reverb`, mas
+  o `pusher/pusher-php-server` não estava instalado. Como o broadcaster do Reverb fala o protocolo
+  Pusher, **qualquer comando `artisan` falhava** após um `cp .env.example .env` — quem clonasse o
+  repositório travava no primeiro comando. Resolvido com
+  `composer require pusher/pusher-php-server`.
 
 ---
 


### PR DESCRIPTION
loses #184

Cria a integração contínua do projeto. Todo PR para `develop` ou `main` passa a rodar
lint, tipos, testes e build automaticamente nos dois apps.

## Por que agora

Depois que o #187 deixou a `develop` verde, bastaram **dois PRs e três dias** para ela
regredir: 4 arquivos fora do padrão do Pint e a suíte de testes quebrada (`composer test`
saindo com exit 2). Foi preciso o #190 só para restaurar o estado. Sem verificação
automática, isso se repete a cada sprint.

A `develop` está verde agora — é a janela certa para ligar a CI, porque o primeiro run
nasce ✓ e o time confia no check em vez de aprender a ignorá-lo.

## O que roda

Dois jobs em paralelo:

| Job | Passos |
|---|---|
| **Backend** (PHP 8.2) | migrations em banco virgem · Pint · PHPUnit |
| **Frontend** (Node 20) | ESLint · `tsc --noEmit` · Vitest · build |

O backend sobe um **PostgreSQL 16 efêmero** como service container — criado e destruído a
cada run, sem nunca encostar no Supabase do time.

Cada execução exibe um **resumo em tabela no topo da página** (Job Summary), com o
resultado das sete verificações e a contagem de testes. Usa `if: always()`, então aparece
também quando algo falha — que é justamente quando mais ajuda.

## Três decisões que valem explicação

**1. Os testes rodam contra Postgres sem alterar o `phpunit.xml`.**

O `phpunit.xml` fixa `DB_CONNECTION=sqlite`, mas **sem `force="true"`**. O PHPUnit só aplica
um `<env>` se a variável ainda não existir no ambiente
(`PhpHandler.php:112`: `if ($force || getenv($name) === false)`). Então o `env:` do job vence
o XML.

Isso importa porque o arquivo é escopo do #160, de outra pessoa — assim não há conflito de
merge, e ninguém precisa de Postgres local para rodar `composer test`.

Verificado empiricamente: com as variáveis, `database.default` é `pgsql` e o driver real é
PostgreSQL 16.14; sem elas, `sqlite`.

> ⚠️ **Para quem for fazer o #160:** se adicionar `force="true"` ao `phpunit.xml`, a CI volta
> silenciosamente para SQLite e este job perde o sentido.

**2. `npx tsc --noEmit` entrou no job de frontend.**

O `npm run build` usa esbuild, que **apaga** as anotações de tipo sem verificá-las. O ESLint
olha estilo, não tipos. Ou seja, hoje **nada** valida TypeScript no projeto —
`mesasService.update(id, { status: 123 })` passaria no build e no lint.

Já passa limpo no código atual, então entra sem obrigar ninguém a consertar nada.

Ressalva registrada para depois: o `tsconfig.json` tem `strictNullChecks` e `noImplicitAny`
desligados, então a checagem é de malha larga. Apertar isso é decisão do time e fica como
issue própria, a ser avaliada **depois** da CI existir — aí dá para medir o estrago com um
comando.

**3. Sem filtro por `paths`** — e isso reverte um critério escrito na própria issue.

Se um job não roda por causa de filtro, ele nunca reporta status, e o check obrigatório do
#185 deixaria o PR travado para sempre em *waiting for status*. Rodar sempre custa ~4 min.
O critério foi corrigido em `docs/backlog-pi4.md`.

## Bug encontrado e corrigido junto

```bash
cp .env.example .env
php artisan key:generate
# → RuntimeException: Failed to create broadcaster for connection "reverb"
#   with error: Class "Pusher\Pusher" not found