### PR TITLE
chore: atualiza actions do workflow para o runtime node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       BROADCAST_CONNECTION: "null"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Instalar PHP
         uses: shivammathur/setup-php@v2
@@ -86,7 +86,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Restaurar cache do Composer
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ runner.os }}-${{ hashFiles('deep-dish-backend/composer.lock') }}
@@ -155,10 +155,10 @@ jobs:
         working-directory: deep-dish-frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Instalar Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           # Mesma versao do servico frontend no docker-compose.yml.
           node-version: '20'


### PR DESCRIPTION
Silencia o aviso de depreciação que apareceu no primeiro run da CI.

## O aviso

Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, actions/cache@v4



**Não tem relação com o Node 20 que usamos no job de frontend** — esse continua igual, e é
o mesmo do serviço `frontend` no `docker-compose`. O aviso é sobre o runtime interno que as
*actions* usam para executar seu próprio código. O GitHub está aposentando o Node 20 nessa
função e já força o 24; as versões `@v4` param de funcionar quando ele desligar de vez.

## O que mudou

| Action | Antes | Depois |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/cache` | v4 | **v6** |

`shivammathur/setup-php@v2` ficou como está — já roda em node24, e por isso não apareceu
no aviso.

## Verificação

Antes de atualizar, conferi via API o `action.yml` de cada versão nova:

- **Runtime:** as três agora usam `node24` ✅
- **Parâmetros que passamos continuam existindo:** `node-version`, `cache` e
  `cache-dependency-path` no `setup-node`; `path`, `key` e `restore-keys` no `cache`;
  o `checkout` usamos sem parâmetro nenhum ✅

O salto de major é grande (v4 → v6/v7), mas essas actions mudaram de major principalmente
por causa do runtime — a interface pública que consumimos é a mesma. O YAML continua
parseando com 10 e 9 passos.

O próprio run deste PR confirma que funciona.