### PR TITLE
docs: registra as regras automatizadas de merge no guia de contribuicao

### DIFF
--- a/Deep_Dish_Contributing_Guide.md
+++ b/Deep_Dish_Contributing_Guide.md
@@ -63,6 +63,41 @@ Formato obrigatório:
 -   Somente o **Tech Lead** pode aprovar PRs e realizar merges para
     `develop` e `main`.
 
+### Regras aplicadas automaticamente pelo GitHub
+
+As exigências abaixo não dependem de ninguém lembrar: o botão de merge fica
+bloqueado até que todas sejam atendidas. Valem inclusive para quem é admin do
+repositório.
+
+| Exigência | O que significa |
+|---|---|
+| **Pull Request** | Push direto em `develop` ou `main` é recusado pelo servidor |
+| **1 aprovação** | De outra pessoa — o GitHub não permite aprovar o próprio PR |
+| **Aprovação recente** | Commit novo derruba a aprovação anterior, exigindo nova revisão |
+| **CI verde** | Os checks `Backend (PHP 8.2)` e `Frontend (Node 20)` precisam passar |
+| **Branch atualizada** | O PR precisa conter a `develop` mais recente antes do merge |
+| **Conversas resolvidas** | Todo comentário de revisão precisa ser marcado como resolvido |
+
+**Sobre a branch atualizada:** se alguém mergear enquanto o seu PR está aberto,
+aparece o botão **Update branch**. Clique nele e aguarde a CI rodar de novo
+(~40s). Isso existe porque dois PRs verdes separadamente podem quebrar quando
+combinados — foi o que aconteceu em agosto/2026 e custou um PR extra só de
+conserto.
+
+### Procedimento de emergência
+
+Se o GitHub Actions estiver fora do ar, os checks nunca reportam e **ninguém
+consegue mergear** — nem o admin. Nesse caso:
+
+1.  O admin vai em **Settings → Branches → Edit** na branch travada;
+2.  desmarca temporariamente *Require status checks to pass*;
+3.  faz o merge;
+4.  **religa a opção imediatamente**;
+5.  registra no PR o motivo do desbloqueio.
+
+Isso é exceção, não atalho. Se estiver acontecendo com frequência, o problema
+é a CI, não a regra.
+
 ------------------------------------------------------------------------
 
 ## 5. Code Review Padronizado
@@ -115,9 +150,12 @@ Itens marcados como obrigatórios devem ser corrigidos antes do merge.
 
 ## Regras Finais
 
--   Commits diretos em `main` ou `develop` não são permitidos.
+-   Commits diretos em `main` ou `develop` não são permitidos — o GitHub
+    recusa o push.
 -   Branch fora do padrão será recusada.
--   Merge sem aprovação do Tech Lead é proibido.
+-   Merge sem aprovação do Tech Lead é proibido — e agora bloqueado
+    tecnicamente, não só por convenção.
+-   Merge com a CI vermelha é bloqueado.
 -   Notes do Tech Lead devem ser tratadas como obrigatórias.
 
 ------------------------------------------------------------------------

--- a/docs/backlog-pi4.md
+++ b/docs/backlog-pi4.md
@@ -1133,22 +1133,48 @@ lint, teste e build só rodam se alguém lembrar de rodar na própria máquina.
 
 `labels: chore, infra` · `1 ponto` · **Depende de: #31**
 
-**Contexto.** O `Deep_Dish_Contributing_Guide.md` já diz que só o Tech Lead faz merge em `develop`
-e `main`, mas isso é convenção verbal — nada impede tecnicamente um push direto. Esta issue dá
-trava técnica à regra que já existe no papel.
+**Contexto.** A CI da `#31` já roda em todo PR, mas o resultado é **apenas informativo** — nada
+impede mergear com o check vermelho. Esta issue transforma o aviso em trava.
 
-**Só executar depois de a CI rodar verde por pelo menos um sprint.** Tornar obrigatório cedo demais
-transforma falso positivo em bloqueio de trabalho.
+**Só executar depois de a CI rodar verde num PR real.** Tornar obrigatório cedo demais transforma
+falso positivo em bloqueio de trabalho.
+
+**Descoberta que reduziu o escopo:** a branch protection **já existia** em `develop` e `main`, e bem
+configurada — PR obrigatório, 1 aprovação, `dismiss_stale_reviews`, `enforce_admins`, sem force
+push, sem deleção, conversas resolvidas. **Faltava só `required_status_checks`.** Ou seja, a issue
+é habilitar uma opção num conjunto que já estava de pé, não montar o conjunto.
+
+Confirmado também que a regra de aprovação já vinha sendo cumprida na prática: os quatro PRs
+mergeados até aqui (#187, #190, #191, #192) foram aprovados pelo `jpvoliveir` — o `enforce_admins`
+impede o dono do repositório de mergear o próprio trabalho sem revisão, e o GitHub não permite
+aprovar o próprio PR.
 
 **Tarefas**
-- Branch protection em `develop` e `main`: exigir os checks da #31, exigir PR com aprovação,
-  bloquear push direto.
-- Registrar no `Deep_Dish_Contributing_Guide.md` que a regra agora é aplicada automaticamente.
+- Habilitar `required_status_checks` em `develop` e `main`, com os contextos exatos
+  `Backend (PHP 8.2)` e `Frontend (Node 20)`.
+- Registrar no `Deep_Dish_Contributing_Guide.md` as regras automatizadas e o procedimento de
+  emergência.
+
+**Decisões**
+- **`strict: true`** (branch atualizada antes do merge). Pega a falha de agosto/2026: os PRs #187,
+  #188 e #189 estavam verdes separadamente e a `develop` combinada quebrou, exigindo o #190 só para
+  consertar. Custo: `Update branch` + ~40s de CI sempre que alguém mergear antes.
+- **`enforce_admins` mantido ativo.** A regra vale para todos. Se o Actions cair, o caminho é
+  desligar a proteção em Settings, mergear e religar — ato deliberado e visível, documentado no
+  guia.
+- **Branch protection clássica, não rulesets.** O repositório já usa o mecanismo clássico; misturar
+  os dois criaria duas fontes de regra concorrendo.
+
+⚠️ **Cuidado ao aplicar por API:** o `PATCH` em `/branches/{branch}/protection` **substitui o
+objeto inteiro** — omitir um campo o desliga. Enviar só `required_status_checks` derrubaria a
+exigência de PR e o `enforce_admins` sem aviso. Pela interface esse risco não existe.
 
 **Critérios de aceite**
 - [ ] Push direto em `develop` é rejeitado pelo GitHub.
 - [ ] PR com CI vermelha não pode ser mergeada.
-- [ ] O guia de contribuição reflete a regra automatizada.
+- [ ] PR desatualizado exige `Update branch` antes do merge.
+- [ ] Nenhuma das regras que já existiam foi perdida (comparar a proteção antes e depois).
+- [ ] O guia de contribuição reflete as regras automatizadas e o procedimento de emergência.
 
 ---
 


### PR DESCRIPTION
Closes #185

Documenta as regras que passam a ser aplicadas automaticamente pelo GitHub no merge,
junto da ativação dos checks obrigatórios da CI.

## O escopo era menor do que parecia

A branch protection **já existia** em `develop` e `main`, e bem configurada: PR obrigatório,
1 aprovação, `dismiss_stale_reviews`, `enforce_admins`, sem force push, sem deleção e
conversas resolvidas.

Faltava **uma peça só**: `required_status_checks`. Era por isso que a CI aparecia no PR
mas não bloqueava nada.

## O que foi ativado

Em `develop` e `main`, pela interface do GitHub:

- **Require status checks to pass** — com os contextos `Backend (PHP 8.2)` e `Frontend (Node 20)`
- **Require branches to be up to date before merging**

## A decisão do `strict` (branch atualizada)

É a mudança que mais afeta o dia a dia, então vale o porquê.

Semana passada os PRs #187, #188 e #189 estavam verdes **separadamente**, e a `develop`
combinada quebrou — foi preciso o #190 só para consertar. Cada PR foi testado contra uma
`develop` antiga; ninguém testou o resultado do merge.

Com essa opção, um PR desatualizado exige `Update branch` e uma nova execução da CI antes
de liberar o merge. Custa ~40s por vez; o PR de conserto custou muito mais.

## Sobre o `enforce_admins`

Mantido ativo — a regra vale para todos, inclusive para o dono do repositório. Isso já vinha
sendo cumprido na prática: os quatro PRs mergeados até aqui (#187, #190, #191, #192) foram
todos aprovados pelo @jpvoliveir, porque o GitHub não permite aprovar o próprio PR.

O efeito colateral é que uma queda do GitHub Actions bloqueia todo mundo. Por isso o guia
ganhou um **procedimento de emergência** explícito: desligar a proteção, mergear, religar e
registrar o motivo no PR — um ato deliberado e visível, não um atalho silencioso.

## Alterações

- **`Deep_Dish_Contributing_Guide.md`** — nova seção com a tabela das seis exigências
  automáticas, a explicação do `Update branch` e o procedimento de emergência. As *Regras
  Finais* passam a dizer que o bloqueio é técnico, não só convenção.
- **`docs/backlog-pi4.md`** — registrado que a proteção já existia, as três decisões tomadas
  e o alerta sobre o `PATCH` da API substituir o objeto inteiro.

## Verificação

- Estado da proteção comparado antes e depois, para garantir que nenhuma das regras
  existentes se perdeu
- Teste positivo: este PR passa pela CI e mergeia normalmente
- Teste negativo pendente: quebrar o lint de propósito num PR e confirmar que o merge trava
