### PR TITLE
feat: endpoint GET /restaurante/analytics expondo os agregados histor…

### DIFF
--- a/deep-dish-backend/app/Http/Controllers/AnalyticsController.php
+++ b/deep-dish-backend/app/Http/Controllers/AnalyticsController.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\AnalyticsService;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+
+/**
+ * Leitura do histórico operacional do restaurante autenticado.
+ *
+ * Separado do DashboardController de proposito: aquele responde "como esta a
+ * casa agora" (quatro contadores instantaneos) e este responde "como foi ate
+ * aqui". Sao perguntas diferentes, com custo de consulta diferente, e o
+ * frontend atual depende do /dashboard continuar como esta.
+ */
+class AnalyticsController extends Controller
+{
+    /**
+     * Fuso em que o periodo e interpretado.
+     *
+     * Precisa ser o MESMO que o AnalyticsService usa para agrupar dia e hora.
+     * Se o controller montasse os limites em UTC, o filtro e o agrupamento
+     * discordariam e os dias das bordas entrariam pela metade.
+     */
+    private const FUSO = 'America/Sao_Paulo';
+
+    /** Janela usada quando o cliente nao informa datas. */
+    private const DIAS_PADRAO = 90;
+
+    /** Mesmo teto do AnalyticsService — validado aqui para virar 422, nao 500. */
+    private const MAX_DIAS = 366;
+
+    public function __construct(private readonly AnalyticsService $analytics) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        // A ordem entre as datas NAO usa 'after_or_equal:data_inicio': quando o
+        // cliente manda so 'data_fim', a regra tenta interpretar a string
+        // 'data_inicio' como data e rejeita uma requisicao valida. A comparacao
+        // acontece abaixo, ja sobre os limites resolvidos.
+        $validado = $request->validate([
+            'data_inicio' => ['nullable', 'date'],
+            'data_fim' => ['nullable', 'date'],
+        ]);
+
+        [$inicio, $fim] = $this->periodo($validado);
+
+        if ($inicio->greaterThan($fim)) {
+            return response()->json([
+                'error' => 'periodo_invalido',
+                'message' => 'A data inicial nao pode ser posterior a final.',
+            ], 422);
+        }
+
+        // Dia de calendario contra dia de calendario: diffInDays() devolve float,
+        // e de startOfDay ate endOfDay o resultado e 89,999..., nao 90. Comparar
+        // os dois inicios de dia da o numero inteiro que o periodo cobre.
+        $dias = (int) $inicio->startOfDay()->diffInDays($fim->startOfDay()) + 1;
+
+        if ($dias > self::MAX_DIAS) {
+            return response()->json([
+                'error' => 'periodo_muito_longo',
+                'message' => 'Periodo de no maximo '.self::MAX_DIAS.' dias por consulta.',
+            ], 422);
+        }
+
+        $restauranteId = (string) auth('restaurante')->id();
+
+        try {
+            return response()->json([
+                // Ecoa o periodo efetivamente usado: sem isto o frontend nao tem
+                // como rotular o grafico quando o padrao de 90 dias entrou em acao.
+                'periodo' => [
+                    'data_inicio' => $inicio->format('Y-m-d'),
+                    'data_fim' => $fim->format('Y-m-d'),
+                    'dias' => $dias,
+                    'fuso' => self::FUSO,
+                ],
+                'procedencia' => $this->analytics->procedenciaDoHistorico($restauranteId, $inicio, $fim),
+                'espera_por_dia_da_semana' => $this->analytics->tempoMedioDeEsperaPorDiaDaSemana($restauranteId, $inicio, $fim),
+                'espera_por_faixa_horaria' => $this->analytics->tempoMedioDeEsperaPorFaixaHoraria($restauranteId, $inicio, $fim),
+                'abandono' => $this->analytics->taxaDeAbandono($restauranteId, $inicio, $fim),
+                'ocupacao' => $this->analytics->taxaDeOcupacao($restauranteId, $inicio, $fim),
+                'giro_de_mesa' => $this->analytics->giroDeMesa($restauranteId, $inicio, $fim),
+                'mapa_de_calor' => $this->analytics->mapaDeCalorDeDemanda($restauranteId, $inicio, $fim),
+            ]);
+        } catch (InvalidArgumentException $e) {
+            // Rede de seguranca: as guardas do servico ja foram cobertas acima,
+            // mas uma regra nova la nao pode virar 500 aqui.
+            return response()->json([
+                'error' => 'periodo_invalido',
+                'message' => $e->getMessage(),
+            ], 422);
+        }
+    }
+
+    /**
+     * Resolve o periodo da consulta, sempre em horario local do restaurante.
+     *
+     * O padrao de 90 dias casa com as ~12 semanas que o 'historico:sintetico'
+     * gera, entao o dashboard abre com grafico cheio em vez de pedir ao usuario
+     * que escolha uma data antes de ver qualquer coisa.
+     *
+     * Os limites vao para o inicio e o fim do dia porque o cliente manda data
+     * ('2026-08-01'), nao instante: sem o endOfDay o ultimo dia entraria so ate
+     * a meia-noite e apareceria vazio no grafico.
+     *
+     * @param  array{data_inicio?:string|null, data_fim?:string|null}  $validado
+     * @return array{0:CarbonImmutable, 1:CarbonImmutable}
+     */
+    private function periodo(array $validado): array
+    {
+        $fim = isset($validado['data_fim'])
+            ? $this->diaLocal($validado['data_fim'])->endOfDay()
+            : CarbonImmutable::now(self::FUSO)->endOfDay();
+
+        $inicio = isset($validado['data_inicio'])
+            ? $this->diaLocal($validado['data_inicio'])->startOfDay()
+            : $fim->subDays(self::DIAS_PADRAO - 1)->startOfDay();
+
+        return [$inicio, $fim];
+    }
+
+    /**
+     * Interpreta a entrada como DIA DE CALENDARIO no fuso do restaurante.
+     *
+     * Hora e fuso que venham na string sao descartados de proposito:
+     * '2026-08-01' e '2026-08-01T00:00:00Z' significam o mesmo dia para quem
+     * opera a casa, e a alternativa e pior de duas formas.
+     *
+     * Passar o fuso como 2o argumento do parse() NAO resolve: esse parametro so
+     * vale quando a string nao carrega fuso proprio. Com o 'Z' ele e ignorado, o
+     * objeto fica em UTC, e o startOfDay()/endOfDay() seguinte recorta o dia
+     * errado — o periodo respondido saia deslocado em um dia.
+     */
+    private function diaLocal(string $valor): CarbonImmutable
+    {
+        $data = CarbonImmutable::parse($valor)->format('Y-m-d');
+
+        return CarbonImmutable::parse($data, self::FUSO);
+    }
+}

--- a/deep-dish-backend/app/Services/AnalyticsService.php
+++ b/deep-dish-backend/app/Services/AnalyticsService.php
@@ -471,7 +471,18 @@ class AnalyticsService
             throw new InvalidArgumentException('A data inicial do período não pode ser posterior à final.');
         }
 
-        if ($inicio->diffInDays($fim) + 1 > self::MAX_DIAS) {
+        // Dia de calendário contra dia de calendário, NO FUSO DO RESTAURANTE.
+        //
+        // Duas coisas dependem disso. Primeiro, diffInDays() devolve float: de
+        // startOfDay até endOfDay o resultado é 365,999..., e o '+1' passava de
+        // MAX_DIAS por uma fração, rejeitando exatamente o período máximo que
+        // esta guarda deveria permitir. Segundo, o setTimezone tem de estar aqui
+        // porque diasDoPeriodo() enumera em self::FUSO — contar em um fuso e
+        // enumerar em outro faz a série responder um dia diferente do pedido.
+        $diasCorridos = (int) $inicio->copy()->setTimezone(self::FUSO)->startOfDay()
+            ->diffInDays($fim->copy()->setTimezone(self::FUSO)->startOfDay());
+
+        if ($diasCorridos + 1 > self::MAX_DIAS) {
             throw new InvalidArgumentException('Período de no máximo '.self::MAX_DIAS.' dias por consulta.');
         }
     }

--- a/deep-dish-backend/routes/api.php
+++ b/deep-dish-backend/routes/api.php
@@ -77,6 +77,9 @@ Route::prefix('restaurante')->middleware(['auth:restaurante', \App\Http\Middlewa
 Route::prefix('restaurante')->middleware(['auth:restaurante', \App\Http\Middleware\VerifyJwtTokenVersion::class, \App\Http\Middleware\EnsureEmailIsVerified::class])->group(function () {
     Route::get('/dashboard', [App\Http\Controllers\DashboardController::class, 'stats']);
 
+    // Historico operacional. O /dashboard acima continua sendo o estado atual.
+    Route::get('/analytics', [App\Http\Controllers\AnalyticsController::class, 'index']);
+
     Route::get('/me', [App\Http\Controllers\Auth\RestauranteAuthController::class, 'me']);
     Route::put('/me', [App\Http\Controllers\Auth\RestauranteAuthController::class, 'update']);
     Route::post('/me/imagem', [App\Http\Controllers\Auth\RestauranteAuthController::class, 'uploadImagem']);

--- a/deep-dish-backend/tests/Feature/AnalyticsEndpointTest.php
+++ b/deep-dish-backend/tests/Feature/AnalyticsEndpointTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Cliente;
+use App\Models\ClienteFila;
+use App\Models\Fila;
+use App\Models\Mesa;
+use App\Models\Restaurante;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * GET /api/restaurante/analytics (#162).
+ *
+ * ── Por que nao usa actingAs() ──
+ * A rota passa por VerifyJwtTokenVersion, que chama JWTAuth::parseToken() e le
+ * o header Authorization. Com actingAs() nao existe token na requisicao, o
+ * parse lanca e o middleware devolve 401 — o teste falharia por falta de token,
+ * nao pela regra sendo testada. Por isso todo caso autenticado aqui emite um
+ * JWT de verdade via auth('restaurante')->login(), que ja embute a claim
+ * 'token_version' atraves de Restaurante::getJWTCustomClaims().
+ *
+ * Este e o primeiro teste do projeto que exercita a pilha de middlewares por
+ * HTTP: o FilaServiceTest instancia o controller direto e nao passa por ela.
+ */
+class AnalyticsEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const ROTA = '/api/restaurante/analytics';
+
+    private const FUSO = 'America/Sao_Paulo';
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    // ─── Acesso e autorizacao ────────────────────────────────
+
+    public function test_restaurante_autenticado_recebe_o_payload_completo(): void
+    {
+        $restaurante = $this->restaurante();
+        Mesa::factory()->count(2)->for($restaurante)->create();
+
+        $fila = Fila::factory()->for($restaurante)->create();
+        $this->entrada($fila, $this->local('-10 days 13:00'), 20, ClienteFila::STATUS_SAIDA_ATENDIDO);
+
+        $resposta = $this->comToken($restaurante)->getJson(self::ROTA);
+
+        $resposta->assertOk()->assertJsonStructure([
+            'periodo' => ['data_inicio', 'data_fim', 'dias', 'fuso'],
+            'procedencia' => ['fila', 'reservas', 'contem_sintetico'],
+            'espera_por_dia_da_semana',
+            'espera_por_faixa_horaria',
+            'abandono' => ['total_entradas', 'abandonos', 'taxa', 'taxa_percentual'],
+            'ocupacao',
+            'giro_de_mesa' => ['mesas', 'total_atendimentos', 'duracao_media_geral_segundos'],
+            'mapa_de_calor' => ['celulas', 'pico'],
+        ]);
+
+        // As series vem completas mesmo com um unico registro no periodo.
+        $this->assertCount(7, $resposta->json('espera_por_dia_da_semana'));
+        $this->assertCount(24, $resposta->json('espera_por_faixa_horaria'));
+        $this->assertCount(168, $resposta->json('mapa_de_calor.celulas'));
+        $this->assertCount(2, $resposta->json('giro_de_mesa.mesas'));
+        $this->assertSame(1, $resposta->json('abandono.total_entradas'));
+    }
+
+    public function test_sem_token_devolve_401(): void
+    {
+        $this->getJson(self::ROTA)->assertUnauthorized();
+    }
+
+    public function test_token_de_cliente_nao_acessa_endpoint_de_restaurante(): void
+    {
+        $cliente = Cliente::factory()->create();
+        $token = auth('api')->login($cliente);
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson(self::ROTA)
+            ->assertUnauthorized();
+    }
+
+    public function test_restaurante_com_email_nao_verificado_recebe_403(): void
+    {
+        $restaurante = Restaurante::factory()->naoVerificado()->create();
+
+        $this->comToken($restaurante)
+            ->getJson(self::ROTA)
+            ->assertForbidden()
+            ->assertJsonPath('error', 'email_not_verified');
+    }
+
+    // ─── Periodo ─────────────────────────────────────────────
+
+    public function test_periodo_padrao_cobre_os_ultimos_90_dias(): void
+    {
+        $restaurante = $this->restaurante();
+
+        $resposta = $this->comToken($restaurante)->getJson(self::ROTA);
+
+        $resposta->assertOk()
+            ->assertJsonPath('periodo.dias', 90)
+            ->assertJsonPath('periodo.fuso', self::FUSO)
+            ->assertJsonPath('periodo.data_fim', Carbon::now(self::FUSO)->format('Y-m-d'));
+
+        // 90 dias de janela => 90 pontos na serie diaria de ocupacao.
+        $this->assertCount(90, $resposta->json('ocupacao'));
+    }
+
+    public function test_respeita_as_datas_informadas(): void
+    {
+        $restaurante = $this->restaurante();
+
+        $resposta = $this->comToken($restaurante)->getJson(
+            self::ROTA.'?data_inicio=2026-08-01&data_fim=2026-08-31'
+        );
+
+        $resposta->assertOk()
+            ->assertJsonPath('periodo.data_inicio', '2026-08-01')
+            ->assertJsonPath('periodo.data_fim', '2026-08-31')
+            ->assertJsonPath('periodo.dias', 31);
+
+        $this->assertCount(31, $resposta->json('ocupacao'));
+    }
+
+    public function test_apenas_data_fim_ainda_e_aceito(): void
+    {
+        // Guarda de regressao: com a regra 'after_or_equal:data_inicio' do
+        // Laravel, este caso quebrava — a regra tentava ler a string literal
+        // 'data_inicio' como data e rejeitava uma requisicao valida.
+        $this->comToken($this->restaurante())
+            ->getJson(self::ROTA.'?data_fim=2026-08-31')
+            ->assertOk()
+            ->assertJsonPath('periodo.data_fim', '2026-08-31')
+            ->assertJsonPath('periodo.dias', 90);
+    }
+
+    public function test_data_com_fuso_na_string_e_tratada_como_dia_de_calendario(): void
+    {
+        // O frontend pode mandar ISO completo ('...T00:00:00Z'). Nesse caso o
+        // 2o argumento do Carbon::parse e ignorado, o objeto fica em UTC e o
+        // startOfDay/endOfDay recorta o dia errado — a serie voltava comecando
+        // no dia anterior ao pedido.
+        $resposta = $this->comToken($this->restaurante())->getJson(
+            self::ROTA.'?data_inicio=2026-08-01T00:00:00Z&data_fim=2026-08-31T00:00:00Z'
+        );
+
+        $resposta->assertOk()
+            ->assertJsonPath('periodo.data_inicio', '2026-08-01')
+            ->assertJsonPath('periodo.data_fim', '2026-08-31')
+            ->assertJsonPath('periodo.dias', 31);
+
+        $ocupacao = $resposta->json('ocupacao');
+
+        $this->assertCount(31, $ocupacao, 'A serie tem de cobrir os 31 dias pedidos, nem um a mais.');
+        $this->assertSame('2026-08-01', $ocupacao[0]['data'], 'A serie nao pode comecar no dia anterior.');
+        $this->assertSame('2026-08-31', $ocupacao[30]['data']);
+    }
+
+    public function test_data_final_antes_da_inicial_devolve_422(): void
+    {
+        $this->comToken($this->restaurante())
+            ->getJson(self::ROTA.'?data_inicio=2026-08-31&data_fim=2026-08-01')
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'periodo_invalido');
+    }
+
+    public function test_periodo_acima_do_teto_devolve_422_e_nao_500(): void
+    {
+        $this->comToken($this->restaurante())
+            ->getJson(self::ROTA.'?data_inicio=2024-01-01&data_fim=2026-01-01')
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'periodo_muito_longo');
+    }
+
+    public function test_exatamente_366_dias_e_aceito(): void
+    {
+        // O teto documentado e 366 dias INCLUSIVE. Este teste existe porque a
+        // contagem por float ('89,999... + 1') faria o limite rejeitar o proprio
+        // valor maximo — de 2026-01-01 a 2027-01-01 sao 366 dias de calendario.
+        $this->comToken($this->restaurante())
+            ->getJson(self::ROTA.'?data_inicio=2026-01-01&data_fim=2027-01-01')
+            ->assertOk()
+            ->assertJsonPath('periodo.dias', 366);
+    }
+
+    public function test_data_em_formato_invalido_devolve_422(): void
+    {
+        $this->comToken($this->restaurante())
+            ->getJson(self::ROTA.'?data_inicio=nao-e-uma-data')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('data_inicio');
+    }
+
+    // ─── Isolamento ──────────────────────────────────────────
+
+    public function test_payload_nao_traz_dado_de_outro_restaurante(): void
+    {
+        $meu = $this->restaurante();
+        $outro = $this->restaurante();
+
+        Mesa::factory()->for($meu)->create(['numero' => 1]);
+        Mesa::factory()->count(3)->for($outro)->create();
+
+        $minhaFila = Fila::factory()->for($meu)->create();
+        $filaAlheia = Fila::factory()->for($outro)->create();
+
+        $this->entrada($minhaFila, $this->local('-5 days 13:00'), 10, ClienteFila::STATUS_SAIDA_ATENDIDO);
+        $this->entrada($filaAlheia, $this->local('-5 days 13:00'), 90, ClienteFila::STATUS_SAIDA_DESISTIU);
+        $this->entrada($filaAlheia, $this->local('-4 days 13:00'), 90, ClienteFila::STATUS_SAIDA_DESISTIU);
+
+        $resposta = $this->comToken($meu)->getJson(self::ROTA);
+
+        $resposta->assertOk()
+            ->assertJsonPath('abandono.total_entradas', 1)
+            ->assertJsonPath('abandono.desistiu', 0);
+
+        $this->assertCount(1, $resposta->json('giro_de_mesa.mesas'), 'Só as mesas do restaurante autenticado.');
+    }
+
+    // ─── Criterio de aceite: o dashboard nao pode ter mudado ──
+
+    public function test_dashboard_continua_respondendo_como_antes(): void
+    {
+        $restaurante = $this->restaurante();
+        Mesa::factory()->count(3)->for($restaurante)->create();
+
+        $this->comToken($restaurante)
+            ->getJson('/api/restaurante/dashboard')
+            ->assertOk()
+            ->assertJsonStructure(['queue_size', 'reservations_today', 'tables_available', 'total_tables'])
+            ->assertJsonPath('total_tables', 3);
+    }
+
+    // ───────────────────────── Helpers ─────────────────────────
+
+    private function restaurante(): Restaurante
+    {
+        return Restaurante::factory()->create([
+            'horario_abertura' => '11:00',
+            'horario_fechamento' => '23:00',
+        ]);
+    }
+
+    /**
+     * Emite um JWT real e o anexa ao header, como o frontend faz.
+     *
+     * @return $this
+     */
+    private function comToken(Restaurante $restaurante): static
+    {
+        return $this->withHeader('Authorization', 'Bearer '.auth('restaurante')->login($restaurante));
+    }
+
+    /** Instante relativo a agora, em horario local do restaurante. */
+    private function local(string $expressao): Carbon
+    {
+        return Carbon::now(self::FUSO)->modify($expressao);
+    }
+
+    /**
+     * Entrada de fila historica, com chegada e saida controladas.
+     *
+     * Mesma tecnica do AnalyticsServiceTest: tudo convertido para UTC antes de
+     * gravar e antes do setTestNow(), porque o Eloquent formata o Carbon no fuso
+     * que ele carrega e o setTestNow descarta o fuso ao congelar o relogio.
+     */
+    private function entrada(Fila $fila, Carbon $chegada, int $esperaMinutos, string $status): void
+    {
+        $chegadaUtc = $chegada->copy()->utc();
+
+        Carbon::setTestNow($chegadaUtc->copy()->addMinutes($esperaMinutos));
+
+        try {
+            ClienteFila::factory()
+                ->for($fila)
+                ->create(['created_at' => $chegadaUtc])
+                ->registrarSaida($status);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+}

--- a/deep-dish-backend/tests/Feature/AnalyticsServiceTest.php
+++ b/deep-dish-backend/tests/Feature/AnalyticsServiceTest.php
@@ -459,6 +459,24 @@ class AnalyticsServiceTest extends TestCase
         );
     }
 
+    public function test_periodo_de_exatamente_366_dias_e_aceito(): void
+    {
+        // O teto e inclusive. A contagem por float ('365,999... + 1') fazia a
+        // guarda rejeitar justamente o valor maximo que deveria permitir.
+        //
+        // O endOfDay no fim NAO e detalhe: com as duas pontas em 00:00 a conta
+        // antiga dava 366 exatos e passava, e este teste nao guardaria nada. E
+        // com endOfDay que a diferenca vira 365,999... — e e assim que o
+        // AnalyticsController monta o periodo.
+        $serie = $this->analytics->taxaDeOcupacao(
+            $this->restaurante->id,
+            $this->local('2026-01-01 00:00:00'),
+            $this->local('2027-01-01 00:00:00')->endOfDay()
+        );
+
+        $this->assertCount(366, $serie);
+    }
+
     public function test_periodo_longo_demais_e_rejeitado(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## O que faz

`GET /restaurante/analytics` (#162) — expoe os sete agregados do AnalyticsService
num payload unico, para a #164 (graficos) poder consumi-los.

- Periodo via `?data_inicio=&data_fim=`, ambos opcionais. Padrao: ultimos 90 dias.
- A entrada e um **dia de calendario no fuso do restaurante**; hora e fuso na
  string sao descartados, entao `2026-08-01` e `2026-08-01T00:00:00Z` significam
  a mesma coisa para quem opera a casa.
- Payload traz `periodo` (o que foi efetivamente usado) e `procedencia` (quanto do
  dado e sintetico), alem dos seis indicadores.
- `GET /restaurante/dashboard` intocado — e agora tem teste.

## Correcoes no AnalyticsService

Duas, ambas encontradas ao expor a guarda de periodo a requisicoes reais:

1. O teto de 366 dias rejeitava exatamente 366 dias — `diffInDays()` devolve float
   e `365,999... + 1` passa do limite por uma fracao.
2. A guarda contava dias no fuso do chamador enquanto `diasDoPeriodo()` enumera em
   `America/Sao_Paulo`. Um pedido de `2026-01-01` a `2027-01-01` respondia uma
   serie comecando em `2025-12-31`.

## Testes

14 testes novos. Suite inteira: **57 passando**, 235 assertions. Pint verde.

Primeiro teste HTTP autenticado do projeto. `actingAs()` nao funciona aqui: o
`VerifyJwtTokenVersion` chama `JWTAuth::parseToken()`, que le o header
`Authorization` — sem token real o middleware devolve 401 e o teste falharia pelo
motivo errado. Os casos emitem JWT de verdade via `auth('restaurante')->login()`.

Cobrem: 401 sem token, 401 com token de cliente, 403 com e-mail nao verificado,
periodo padrao, datas simples, datas em ISO com fuso, so `data_fim`, periodo
invertido, exatamente no teto, acima do teto, formato invalido, isolamento entre
restaurantes, e o dashboard continuando a responder como antes.

Validado por mutacao: revertendo a guarda do servico caem 2 testes; revertendo a
normalizacao de fuso do controller cai 1, com `32 pontos onde deveriam ser 31`.

## Validado contra dado realista

Com 84 dias de historico sintetico (2.126 entradas), o endpoint devolve pico no
**sabado as 20h**, dois picos com vale a tarde (12h=437, 20h=565, 15h-17h=53/54/40)
e os dias na ordem exata dos multiplicadores do seeder. As variantes de data
(`2026-08-01` e `2026-08-01T00:00:00Z`) respondem series identicas de 31 pontos.

## Fora de escopo

Os graficos no dashboard sao a #164.