### PR TITLE
feat: EstimativaEsperaService com regressao linear sobre o historico …

### DIFF
--- a/deep-dish-backend/app/Services/EstimativaEsperaService.php
+++ b/deep-dish-backend/app/Services/EstimativaEsperaService.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ClienteFila;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Estimativa de quanto tempo um cliente vai esperar na fila.
+ *
+ * ── O que é, e o que NÃO é ──
+ * Isto é uma HEURÍSTICA ESTATÍSTICA, não aprendizado de máquina. O modelo é uma
+ * regressão linear de mínimos quadrados, `espera ≈ a + b · posição`, calculada
+ * pelo próprio Postgres com os agregados regr_intercept(), regr_slope() e
+ * regr_count(). Não há treino, pesos, features aprendidas nem modelo
+ * persistido: cada chamada recalcula a reta sobre o histórico disponível.
+ *
+ * A leitura dos coeficientes é direta e é o que torna o número defensável:
+ *   'a' = custo fixo, o tempo até a primeira mesa vagar naquele horário;
+ *   'b' = minuto marginal por pessoa à frente na fila.
+ *
+ * A escolha por heurística em vez de ML é deliberada e está registrada no
+ * backlog (docs/backlog-pi4.md): doze semanas de operação não geram volume para
+ * treinar um modelo que supere a média condicionada.
+ *
+ * ── Por que a amostra é só quem foi ATENDIDO ──
+ * Quem desistiu produz dado censurado: sabemos que esperou ao menos X e foi
+ * embora, nunca quanto teria esperado até sentar. Incluir essas linhas puxa a
+ * média para baixo justamente nos horários ruins — que são onde mais gente
+ * desiste e onde o número precisa ser honesto. Uma fila em que quatro pessoas
+ * sentaram após 25 min e seis desistiram após 8 min tem média geral de 15 min,
+ * um valor em que ninguém foi atendido.
+ *
+ * ── Por que DB::table e não Eloquent ──
+ * ClienteFila::registrarSaida() faz soft delete ao encerrar a entrada, então
+ * TODA linha concluída tem deleted_at preenchido — e são exatamente essas que
+ * formam o histórico. Consulta via Eloquent sem ->withTrashed() devolveria zero
+ * sem erro nenhum.
+ */
+class EstimativaEsperaService
+{
+    /** Precisa ser o mesmo fuso que o AnalyticsService usa para agrupar. */
+    private const FUSO = 'America/Sao_Paulo';
+
+    /** Observações mínimas para um nível ser considerado confiável. */
+    private const MIN_AMOSTRA = 20;
+
+    /** Tolerância no tamanho do grupo ao recortar o nível específico. */
+    private const TOLERANCIA_GRUPO = 1;
+
+    /** Nível 3: usado quando nenhum histórico serve. Em segundos. */
+    private const PADRAO_FIXO_SEGUNDOS = 300;      // 5 min até a primeira mesa
+
+    private const PADRAO_POR_POSICAO_SEGUNDOS = 180; // 3 min por pessoa à frente
+
+    /** Piso do resultado: nunca prometer espera zero. */
+    private const MINIMO_SEGUNDOS = 60;
+
+    public const NIVEL_ESPECIFICO = 'especifico';
+
+    public const NIVEL_AMPLO = 'amplo';
+
+    public const NIVEL_PADRAO = 'padrao';
+
+    /**
+     * Estima a espera de quem entra na fila na posição informada.
+     *
+     * Responde: "quanto tempo vou esperar se entrar agora?".
+     *
+     * Tenta três níveis, do mais específico ao mais genérico, e informa no
+     * retorno qual deles sustentou o número — a #164 expõe esse campo para o
+     * frontend poder ser honesto sobre a confiança da estimativa.
+     *
+     * Nunca devolve null e nunca lança: sem histórico algum, cai no padrão
+     * declarado nas constantes desta classe.
+     *
+     * @param  int  $posicao  Posição que o cliente ocupará (1 = próximo a ser chamado).
+     * @param  int  $tamanhoGrupo  Quantas pessoas no grupo.
+     * @param  CarbonInterface|null  $momento  Instante da entrada; null = agora.
+     * @return array{espera_estimada_minutos:int, espera_estimada_segundos:int, nivel:string, amostra:int, posicao:int}
+     */
+    public function estimar(
+        string $restauranteId,
+        int $posicao,
+        int $tamanhoGrupo,
+        ?CarbonInterface $momento = null
+    ): array {
+        // Posição 0 ou negativa nao existe: quem entra numa fila vazia é o 1º.
+        $posicao = max(1, $posicao);
+
+        $momento = ($momento ?? now())->copy()->setTimezone(self::FUSO);
+
+        $niveis = [
+            self::NIVEL_ESPECIFICO => fn () => $this->regressao($restauranteId, $momento, $tamanhoGrupo),
+            self::NIVEL_AMPLO => fn () => $this->regressao($restauranteId),
+        ];
+
+        foreach ($niveis as $nivel => $consulta) {
+            $reta = $consulta();
+
+            if ($reta === null) {
+                continue;
+            }
+
+            $segundos = $reta['intercepto'] + $reta['inclinacao'] * $posicao;
+
+            return $this->resposta($segundos, $nivel, $reta['amostra'], $posicao);
+        }
+
+        return $this->resposta(
+            self::PADRAO_FIXO_SEGUNDOS + self::PADRAO_POR_POSICAO_SEGUNDOS * $posicao,
+            self::NIVEL_PADRAO,
+            0,
+            $posicao
+        );
+    }
+
+    /**
+     * Ajusta a reta sobre o histórico, opcionalmente recortado pelo contexto.
+     *
+     * Sem $momento a amostra é o restaurante inteiro (nível amplo). Com ele,
+     * recorta por dia da semana, faixa horária e tamanho de grupo parecido
+     * (nível específico).
+     *
+     * Devolve null quando a amostra não sustenta o número — e o chamador cai
+     * para o próximo nível. São quatro motivos possíveis:
+     *
+     *   1. poucas observações (MIN_AMOSTRA);
+     *   2. regr_slope() devolve NULL, o que acontece quando todos os registros
+     *      estão na MESMA posição — não há reta a traçar com um ponto só de x;
+     *   3. inclinação negativa, que diria "quanto mais gente na frente, menos
+     *      você espera";
+     *   4. intercepto negativo, que produziria estimativa abaixo de zero para
+     *      as primeiras posições.
+     *
+     * Os dois últimos são ruído de amostra pequena, não sinal.
+     *
+     * @return array{intercepto:float, inclinacao:float, amostra:int}|null
+     */
+    private function regressao(
+        string $restauranteId,
+        ?CarbonInterface $momento = null,
+        ?int $tamanhoGrupo = null
+    ): ?array {
+        $local = $this->emFusoLocal('cf.created_at');
+
+        // A posição é numerada ANTES de filtrar por 'atendido': quem entrou na
+        // fila contou todo mundo à frente, tenha essa gente sentado ou
+        // desistido depois. Numerar só os atendidos deslocaria toda a escala
+        // para baixo e achataria a inclinação.
+        $sql = "
+            WITH numeradas AS (
+                SELECT
+                    cf.status_saida,
+                    cf.tempo_espera_segundos,
+                    cf.qntd_pessoas,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY cf.fila_id ORDER BY cf.created_at, cf.id
+                    ) AS posicao,
+                    EXTRACT(DOW FROM {$local})::int AS dia,
+                    EXTRACT(HOUR FROM {$local})::int AS hora
+                FROM clientefila cf
+                JOIN fila f ON f.id = cf.fila_id
+                WHERE f.restaurante_id = ?
+            )
+            SELECT
+                regr_intercept(tempo_espera_segundos, posicao) AS intercepto,
+                regr_slope(tempo_espera_segundos, posicao)     AS inclinacao,
+                regr_count(tempo_espera_segundos, posicao)     AS amostra
+            FROM numeradas
+            WHERE status_saida = ?
+              AND tempo_espera_segundos IS NOT NULL
+        ";
+
+        $bindings = [$restauranteId, ClienteFila::STATUS_SAIDA_ATENDIDO];
+
+        if ($momento !== null) {
+            $sql .= ' AND dia = ? AND hora = ? AND qntd_pessoas BETWEEN ? AND ?';
+            $bindings[] = (int) $momento->dayOfWeek;
+            $bindings[] = (int) $momento->hour;
+            $bindings[] = max(1, ($tamanhoGrupo ?? 1) - self::TOLERANCIA_GRUPO);
+            $bindings[] = ($tamanhoGrupo ?? 1) + self::TOLERANCIA_GRUPO;
+        }
+
+        $linha = DB::selectOne($sql, $bindings);
+
+        $amostra = (int) ($linha->amostra ?? 0);
+
+        if ($amostra < self::MIN_AMOSTRA || $linha->inclinacao === null || $linha->intercepto === null) {
+            return null;
+        }
+
+        $inclinacao = (float) $linha->inclinacao;
+        $intercepto = (float) $linha->intercepto;
+
+        if ($inclinacao < 0 || $intercepto < 0) {
+            return null;
+        }
+
+        return [
+            'intercepto' => $intercepto,
+            'inclinacao' => $inclinacao,
+            'amostra' => $amostra,
+        ];
+    }
+
+    /**
+     * @return array{espera_estimada_minutos:int, espera_estimada_segundos:int, nivel:string, amostra:int, posicao:int}
+     */
+    private function resposta(float $segundos, string $nivel, int $amostra, int $posicao): array
+    {
+        $segundos = (int) round(max(self::MINIMO_SEGUNDOS, $segundos));
+
+        return [
+            // Arredonda para cima: prometer menos do que se entrega irrita mais
+            // do que o contrário.
+            'espera_estimada_minutos' => (int) ceil($segundos / 60),
+            'espera_estimada_segundos' => $segundos,
+            'nivel' => $nivel,
+            'amostra' => $amostra,
+            'posicao' => $posicao,
+        ];
+    }
+
+    /**
+     * Converte a coluna UTC para o fuso do restaurante.
+     *
+     * As colunas guardam UTC (config/app.php), mas o recorte por dia da semana e
+     * faixa horária só faz sentido no horário local — sem isto, o pico de jantar
+     * das 20h cairia na janela das 23h e a amostra sairia trocada.
+     *
+     * A constante é interpolada porque AT TIME ZONE exige literal, e o valor
+     * nunca vem de entrada de usuário.
+     */
+    private function emFusoLocal(string $coluna): string
+    {
+        return "({$coluna} AT TIME ZONE 'UTC' AT TIME ZONE '".self::FUSO."')";
+    }
+}

--- a/deep-dish-backend/tests/Feature/EstimativaEsperaServiceTest.php
+++ b/deep-dish-backend/tests/Feature/EstimativaEsperaServiceTest.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ClienteFila;
+use App\Models\Fila;
+use App\Models\Mesa;
+use App\Models\Restaurante;
+use App\Services\EstimativaEsperaService;
+use Database\Seeders\HistoricoSinteticoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * Cobre a estimativa de espera (#163) e os três níveis de degradação.
+ *
+ * O histórico é montado com uma relação linear CONHECIDA (espera = base +
+ * incremento x posicao) para que os testes verifiquem se o estimador recupera o
+ * numero certo — nao apenas se ele roda sem estourar.
+ *
+ * Cada "fila" do helper e uma semana diferente no mesmo dia e horario: quatro
+ * sabados as 20h, por exemplo. Isso exercita o PARTITION BY do ROW_NUMBER (as
+ * posicoes reiniciam a cada fila) e evita colisao no indice unico de
+ * (restaurante_id, horario_reserva).
+ */
+class EstimativaEsperaServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const FUSO = 'America/Sao_Paulo';
+
+    private EstimativaEsperaService $estimativa;
+
+    private Restaurante $restaurante;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->estimativa = app(EstimativaEsperaService::class);
+        $this->restaurante = Restaurante::factory()->create([
+            'horario_abertura' => '11:00',
+            'horario_fechamento' => '23:00',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    // ─── Nível 1: histórico específico ───────────────────────
+
+    public function test_estimativa_recupera_a_relacao_linear_do_historico(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00'); // sábado
+
+        // 4 semanas x 6 posicoes = 24 observacoes, espera = 10 + 5 x posicao min.
+        $this->historicoLinear($slot, filas: 4, porFila: 6, baseMin: 10, porPosicaoMin: 5);
+
+        $r = $this->estimativa->estimar($this->restaurante->id, 5, 2, $slot);
+
+        $this->assertSame(EstimativaEsperaService::NIVEL_ESPECIFICO, $r['nivel']);
+        $this->assertSame(24, $r['amostra']);
+        // 10 + 5x5 = 35
+        $this->assertSame(35, $r['espera_estimada_minutos']);
+        $this->assertSame(5, $r['posicao']);
+    }
+
+    public function test_estimativa_e_monotonica_na_posicao(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00');
+        $this->historicoLinear($slot, filas: 4, porFila: 6, baseMin: 10, porPosicaoMin: 5);
+
+        $anterior = 0;
+
+        foreach (range(1, 10) as $posicao) {
+            $atual = $this->estimativa->estimar($this->restaurante->id, $posicao, 2, $slot)['espera_estimada_minutos'];
+
+            $this->assertGreaterThan($anterior, $atual, "Posição {$posicao} deveria esperar mais que a anterior.");
+            $anterior = $atual;
+        }
+    }
+
+    // ─── Nível 2: cai para a média ampla ─────────────────────
+
+    public function test_sem_historico_no_slot_cai_para_o_nivel_amplo(): void
+    {
+        // Historico existe na sexta as 12h; a consulta pergunta pelo sabado as 20h.
+        $this->historicoLinear($this->slot('2026-08-21 12:00:00'), filas: 4, porFila: 6, baseMin: 10, porPosicaoMin: 5);
+
+        $r = $this->estimativa->estimar($this->restaurante->id, 5, 2, $this->slot('2026-08-22 20:00:00'));
+
+        $this->assertSame(EstimativaEsperaService::NIVEL_AMPLO, $r['nivel']);
+        $this->assertSame(24, $r['amostra']);
+        // A reta e a mesma; so o recorte mudou.
+        $this->assertSame(35, $r['espera_estimada_minutos']);
+    }
+
+    public function test_grupo_muito_maior_que_o_historico_cai_para_o_amplo(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00');
+
+        // Historico so de grupos de 2 pessoas.
+        $this->historicoLinear($slot, filas: 4, porFila: 6, baseMin: 10, porPosicaoMin: 5, pessoas: 2);
+
+        // Grupo de 10 esta fora da tolerancia de +-1, entao o nivel especifico
+        // nao tem amostra.
+        $r = $this->estimativa->estimar($this->restaurante->id, 5, 10, $slot);
+
+        $this->assertSame(EstimativaEsperaService::NIVEL_AMPLO, $r['nivel']);
+    }
+
+    // ─── Nível 3: padrão declarado ───────────────────────────
+
+    public function test_sem_historico_nenhum_devolve_o_padrao(): void
+    {
+        $r = $this->estimativa->estimar($this->restaurante->id, 5, 2, $this->slot('2026-08-22 20:00:00'));
+
+        $this->assertSame(EstimativaEsperaService::NIVEL_PADRAO, $r['nivel']);
+        $this->assertSame(0, $r['amostra']);
+        // 5 min fixos + 3 min x 5 posicoes = 20
+        $this->assertSame(20, $r['espera_estimada_minutos']);
+    }
+
+    public function test_amostra_toda_na_mesma_posicao_nao_qualifica(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00');
+
+        // 25 filas com UMA entrada cada: todas na posicao 1. regr_slope() devolve
+        // NULL sem dois valores distintos de x — nao ha reta a tracar.
+        $this->historicoLinear($slot, filas: 25, porFila: 1, baseMin: 10, porPosicaoMin: 5);
+
+        $r = $this->estimativa->estimar($this->restaurante->id, 5, 2, $slot);
+
+        $this->assertSame(EstimativaEsperaService::NIVEL_PADRAO, $r['nivel']);
+        $this->assertSame(20, $r['espera_estimada_minutos']);
+    }
+
+    public function test_amostra_pequena_nao_qualifica(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00');
+
+        // 2 filas x 4 posicoes = 8 observacoes, abaixo do minimo de 20.
+        $this->historicoLinear($slot, filas: 2, porFila: 4, baseMin: 10, porPosicaoMin: 5);
+
+        $this->assertSame(
+            EstimativaEsperaService::NIVEL_PADRAO,
+            $this->estimativa->estimar($this->restaurante->id, 5, 2, $slot)['nivel']
+        );
+    }
+
+    /**
+     * A posição vem da ordem de CHEGADA, não da ordem de insercao no banco.
+     *
+     * Este teste grava as entradas fora de ordem de proposito. Sem ele a
+     * distincao passa despercebida: o Laravel 12 usa UUIDv7, que e ordenavel por
+     * tempo de geracao, entao 'ORDER BY id' produz o mesmo resultado que
+     * 'ORDER BY created_at' sempre que as linhas nascem em ordem cronologica —
+     * como acontece em producao e nos demais testes.
+     *
+     * Quem grava historico retroativo (o HistoricoSinteticoSeeder, uma
+     * importacao) quebra essa coincidencia, e ai a posicao sairia errada.
+     */
+    public function test_posicao_segue_a_chegada_e_nao_a_ordem_de_insercao(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00');
+
+        foreach (range(0, 3) as $semana) {
+            $inicio = $slot->copy()->subWeeks($semana);
+
+            $fila = Fila::factory()->for($this->restaurante)->create([
+                'horario_reserva' => $inicio->copy()->utc(),
+                'status' => Fila::STATUS_ENCERRADA,
+            ]);
+
+            // Insere na ordem 6,5,4,3,2,1 — o inverso da chegada.
+            foreach ([6, 5, 4, 3, 2, 1] as $posicao) {
+                $this->entrada(
+                    $fila,
+                    $inicio->copy()->addMinutes($posicao - 1),
+                    10 + 5 * $posicao,
+                    ClienteFila::STATUS_SAIDA_ATENDIDO,
+                    2
+                );
+            }
+        }
+
+        $r = $this->estimativa->estimar($this->restaurante->id, 5, 2, $slot);
+
+        $this->assertSame(EstimativaEsperaService::NIVEL_ESPECIFICO, $r['nivel']);
+        // Mesma reta do teste em ordem: 10 + 5x5 = 35.
+        $this->assertSame(35, $r['espera_estimada_minutos']);
+    }
+
+    // ─── Qualidade da amostra ────────────────────────────────
+
+    public function test_desistentes_nao_puxam_a_estimativa_para_baixo(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00');
+
+        $this->historicoLinear($slot, filas: 4, porFila: 6, baseMin: 10, porPosicaoMin: 5);
+        $semDesistentes = $this->estimativa->estimar($this->restaurante->id, 5, 2, $slot);
+
+        // Uma enxurrada de desistencias rapidas: dado censurado, fora da amostra.
+        $this->historicoLinear(
+            $slot->copy()->subWeeks(10),
+            filas: 8,
+            porFila: 6,
+            baseMin: 1,
+            porPosicaoMin: 0,
+            pessoas: 2,
+            status: ClienteFila::STATUS_SAIDA_DESISTIU
+        );
+
+        $comDesistentes = $this->estimativa->estimar($this->restaurante->id, 5, 2, $slot);
+
+        $this->assertSame(
+            $semDesistentes['espera_estimada_minutos'],
+            $comDesistentes['espera_estimada_minutos'],
+            'Quem desistiu nao terminou de esperar — nao pode entrar na conta.'
+        );
+        $this->assertSame(24, $comDesistentes['amostra']);
+    }
+
+    public function test_historico_de_outro_restaurante_nao_influencia(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00');
+
+        $vizinho = Restaurante::factory()->create();
+        $this->historicoLinear($slot, filas: 8, porFila: 6, baseMin: 90, porPosicaoMin: 20, restaurante: $vizinho);
+
+        $r = $this->estimativa->estimar($this->restaurante->id, 5, 2, $slot);
+
+        $this->assertSame(EstimativaEsperaService::NIVEL_PADRAO, $r['nivel']);
+        $this->assertSame(20, $r['espera_estimada_minutos']);
+    }
+
+    // ─── Robustez ────────────────────────────────────────────
+
+    public function test_nunca_devolve_estimativa_nao_positiva(): void
+    {
+        $slot = $this->slot('2026-08-22 20:00:00');
+
+        foreach ([-5, 0, 1, 999] as $posicao) {
+            $r = $this->estimativa->estimar($this->restaurante->id, $posicao, 2, $slot);
+
+            $this->assertGreaterThan(0, $r['espera_estimada_minutos']);
+            $this->assertGreaterThanOrEqual(1, $r['posicao'], 'Posição é normalizada para no mínimo 1.');
+        }
+    }
+
+    public function test_restaurante_inexistente_nao_lanca_e_cai_no_padrao(): void
+    {
+        $r = $this->estimativa->estimar('0199e3d0-0000-7000-8000-000000000000', 3, 2);
+
+        $this->assertSame(EstimativaEsperaService::NIVEL_PADRAO, $r['nivel']);
+        $this->assertSame(14, $r['espera_estimada_minutos']); // 5 + 3x3
+    }
+
+    // ─── Fecha o ciclo com o seeder ──────────────────────────
+
+    /**
+     * O HistoricoSinteticoSeeder gera 'esperaBase = 5 + 3,2 x posicao' minutos,
+     * com fator aleatorio de 0,8 a 1,25 para quem e atendido. Se o estimador
+     * estiver correto, o incremento por posicao que ele recupera tem de ficar
+     * na vizinhanca desses 3,2 min.
+     *
+     * E a diferenca entre testar que o estimador RODA e testar que ele ACERTA.
+     */
+    public function test_estimador_recupera_o_incremento_por_posicao_do_seeder(): void
+    {
+        Mesa::factory()->count(8)->for($this->restaurante)->create();
+
+        app(HistoricoSinteticoSeeder::class)->gerar($this->restaurante, 3);
+
+        $uma = $this->estimativa->estimar($this->restaurante->id, 1, 2);
+        $onze = $this->estimativa->estimar($this->restaurante->id, 11, 2);
+
+        $this->assertNotSame(
+            EstimativaEsperaService::NIVEL_PADRAO,
+            $onze['nivel'],
+            'Com 3 semanas de historico deveria haver amostra suficiente.'
+        );
+
+        $incremento = ($onze['espera_estimada_minutos'] - $uma['espera_estimada_minutos']) / 10;
+
+        $this->assertGreaterThan(1.5, $incremento, "Incremento de {$incremento} min/posicao e baixo demais.");
+        $this->assertLessThan(6.0, $incremento, "Incremento de {$incremento} min/posicao e alto demais.");
+    }
+
+    // ───────────────────────── Helpers ─────────────────────────
+
+    private function slot(string $datahora): Carbon
+    {
+        return Carbon::parse($datahora, self::FUSO);
+    }
+
+    /**
+     * Monta histórico com relação linear conhecida: espera = base + inc x posicao.
+     *
+     * Cada fila e uma semana anterior no MESMO dia da semana e horario, para as
+     * observacoes cairem todas no mesmo recorte do nivel especifico.
+     */
+    private function historicoLinear(
+        Carbon $slot,
+        int $filas,
+        int $porFila,
+        int $baseMin,
+        int $porPosicaoMin,
+        int $pessoas = 2,
+        string $status = ClienteFila::STATUS_SAIDA_ATENDIDO,
+        ?Restaurante $restaurante = null
+    ): void {
+        $restaurante ??= $this->restaurante;
+
+        foreach (range(0, $filas - 1) as $semana) {
+            $inicio = $slot->copy()->subWeeks($semana);
+
+            $fila = Fila::factory()->for($restaurante)->create([
+                'horario_reserva' => $inicio->copy()->utc(),
+                'status' => Fila::STATUS_ENCERRADA,
+            ]);
+
+            foreach (range(1, $porFila) as $posicao) {
+                // +1 min por posicao mantem a ordem de chegada (e portanto o
+                // ROW_NUMBER) sem sair da faixa horaria do slot.
+                $chegada = $inicio->copy()->addMinutes($posicao - 1);
+                $espera = $baseMin + $porPosicaoMin * $posicao;
+
+                $this->entrada($fila, $chegada, $espera, $status, $pessoas);
+            }
+        }
+    }
+
+    /**
+     * Uma entrada histórica com chegada e espera controladas.
+     *
+     * Tudo em UTC antes de gravar e antes do setTestNow(): o Eloquent formata o
+     * Carbon no fuso que ele carrega, e o setTestNow descarta o fuso ao congelar
+     * o relogio. Foi onde os dois bugs do #161 apareceram.
+     */
+    private function entrada(Fila $fila, Carbon $chegada, int $esperaMinutos, string $status, int $pessoas): void
+    {
+        $chegadaUtc = $chegada->copy()->utc();
+
+        Carbon::setTestNow($chegadaUtc->copy()->addMinutes($esperaMinutos));
+
+        try {
+            ClienteFila::factory()
+                ->for($fila)
+                ->create([
+                    'created_at' => $chegadaUtc,
+                    'qntd_pessoas' => $pessoas,
+                ])
+                ->registrarSaida($status);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+}


### PR DESCRIPTION
## O que faz

`EstimativaEsperaService` (#163) — calcula quanto tempo o cliente vai esperar na fila a partir do historico real. Hoje o numero mostrado e o literal `'~30'` cravado em `pages/app/Queue.tsx:316`, que nao muda se a fila tem 1 ou 20 pessoas, se e terca de manha ou sabado a noite.

```php
$s->estimar($restauranteId, posicao: 5, tamanhoGrupo: 2);
// [
//   'espera_estimada_minutos'  => 18,
//   'espera_estimada_segundos' => 1080,
//   'nivel'                    => 'especifico',
//   'amostra'                  => 49,
//   'posicao'                  => 5,
// ]
```

## Modelo

Regressao linear de minimos quadrados `espera = a + b x posicao`, ajustada pelo proprio Postgres com os agregados `regr_intercept()`, `regr_slope()` e `regr_count()`. A leitura dos coeficientes e direta, e e o que torna o numero defensavel: `a` e o tempo ate a primeira mesa vagar naquele horario, `b` e o minuto marginal por pessoa a frente na fila.

**Nao e machine learning**, e o docblock diz isso com todas as letras — nao ha treino, pesos aprendidos nem modelo persistido; cada chamada reajusta a reta sobre a amostra disponivel. A escolha por heuristica esta registrada no `docs/backlog-pi4.md`: doze semanas de operacao nao geram volume para treinar algo que supere a media condicionada.

## Tres niveis de degradacao

O nivel usado volta no payload, para a #164 poder expor e o frontend ser honesto sobre a confianca do numero.

| Nivel | Amostra | Quando |
|---|---|---|
| `especifico` | mesmo dia da semana + faixa horaria + grupo de tamanho similar | amostra suficiente e ao menos 2 posicoes distintas |
| `amplo` | restaurante inteiro, sem recorte | o especifico nao qualifica |
| `padrao` | constantes declaradas na classe | nenhum historico serve |

Nunca devolve `null`, nunca lanca, nunca estima zero.

A exigencia de **duas posicoes distintas** nao e detalhe: `regr_slope()` devolve NULL quando todos os `x` sao iguais, e esse NULL viraria estimativa zerada em silencio.

## Tres decisoes que o codigo documenta

**1. A amostra e so `status_saida = 'atendido'`.** Quem desistiu produz dado censurado: sabemos que esperou ao menos X e foi embora, nunca quanto teria esperado ate sentar. Uma fila em que 4 pessoas sentaram apos 25 min e 6 desistiram apos 8 min tem media geral de 15 min — um valor em que ninguem foi atendido. O vies aparece justamente nos horarios ruins, onde mais gente desiste e onde o numero precisa ser honesto. Medido por mutacao: incluir os desistentes derruba a estimativa de 35 para 13 min.

**2. A posicao vem de `ROW_NUMBER()` sobre `created_at`, numerada ANTES de filtrar por atendido.** Quem entrou na fila contou todo mundo a frente, tenha essa gente sentado ou desistido depois; numerar so os atendidos deslocaria a escala inteira e achataria a inclinacao. E ordena por chegada, nao por `id`.

**3. `DB::table`, nao Eloquent.** `registrarSaida()` faz soft delete, entao toda entrada concluida tem `deleted_at` — e sao exatamente essas que formam o historico. Consulta via Eloquent sem `withTrashed()` devolveria zero sem erro.

## Validado contra dado real

Com 84 dias de historico sintetico no banco de desenvolvimento:

```
-- sabado 20h (pico de jantar) --
  pos  1:   6 min | especifico | amostra=49
  pos  5:  18 min | especifico | amostra=49
  pos 10:  33 min | especifico | amostra=49

-- terca 15h (horario morto) --
  pos  5:  19 min | amplo      | amostra=1659
```

Incremento recuperado: **3,0 min por posicao**. O `HistoricoSinteticoSeeder` gera com `esperaBase = 5 + 3.2 * posicao`. O estimador reconstruiu o coeficiente a partir do dado, sem nunca ter visto a formula.

No horario morto ele cai sozinho para `amplo` em vez de inventar um numero.

## Testes

13 testes novos. Suite inteira: **70 passando**, 282 assertions. Pint verde.

Inclui um teste que roda o `HistoricoSinteticoSeeder` de verdade e verifica que o incremento recuperado fica na vizinhanca dos 3,2 min/posicao que ele gera — a diferenca entre testar que o estimador roda e testar que ele acerta.

Validado por mutacao. Uma delas foi util alem do esperado: trocar `ORDER BY created_at` por `ORDER BY id` **nao quebrou teste nenhum**, porque o Laravel 12 usa UUIDv7 (ordenavel por tempo) e as linhas nasciam em ordem cronologica. A distincao existia no codigo mas nao estava protegida. Foi adicionado `test_posicao_segue_a_chegada_e_nao_a_ordem_de_insercao`, que grava as entradas invertidas (6,5,4,3,2,1) — importa porque historico retroativo, como o do proprio seeder ou uma importacao futura, quebra essa coincidencia e faria a posicao sair errada em silencio.

## Follow-up conhecido

A constante `FUSO = 'America/Sao_Paulo'` agora existe em tres lugares (`AnalyticsService`, `AnalyticsController`, `EstimativaEsperaService`). Centralizar em config e a decisao certa, mas mexeria em dois arquivos recem-mergeados e inflaria este diff. Vale uma issue de `chore:`.

## Fora de escopo

Expor em `POST /fila`, `GET /fila/posicao` e `GET /restaurante/fila` e a **#164** (2 pts) — o servico ja devolve tudo pronto. A tela do cliente e a **#167**.